### PR TITLE
feat: quanrantine failed migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o mfx-migrator .
 FROM debian:buster-slim
 
 # Install cron to schedule the job.
-RUN apt-get update && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cron jq && rm -rf /var/lib/apt/lists/*
 
 # The application configuration file should be stored in /mfx-migrator
 VOLUME /mfx-migrator

--- a/scripts/claim_and_migrate.sh
+++ b/scripts/claim_and_migrate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 WORKDIR=/jobs
+QUARANTINE_DIR=/quarantine
 
 cd "$WORKDIR" || exit 1
 
@@ -9,3 +10,21 @@ mfx-migrator claim
 
 # Run the migration for each JSON file in the workdir
 find . -name '*.json' ! -name "config.json" -print0 | xargs -0 -I{} -P 1 bash -c 'mfx-migrator migrate --uuid $(basename "{}" .json)'
+
+# Check each JSON file for a failed status and a non-empty error
+for file in *.json; do
+    if [ "$file" == "config.json" ]; then
+        continue
+    fi
+
+    status=$(jq -r '.status' "$file")
+    error=$(jq -r '.error' "$file")
+
+    if [[ "$status" -eq 5 ]] && [[ -n "$error" ]]; then
+        # If the quarantine directory doesn't exist, create it
+        mkdir -p "$QUARANTINE_DIR"
+
+        # Move the file to the quarantine directory
+        mv "$file" "$QUARANTINE_DIR/"
+    fi
+done


### PR DESCRIPTION
Move failed migration to a quarantine folder.

Re-executing a migration involves
1) Move to the /quarantine folder
2) Force reclaiming the migration
3) Move the reclaimed migration file to the /jobs folder
4) Let the cron job re-execute the migration

Fixes #19 