### PR TITLE
feat: version subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ help: ## Display this help screen
 
 #### BUILD ####
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+BUILD_FLAGS := -ldflags "-X github.com/liftedinit/mfx-migrator/cmd.Version=$(VERSION)"
+
 build: ## Build the project
-	@echo "--> Building project"
-	@go build -o mfx-migrator ./
+	@echo "--> Building project (version: $(VERSION))"
+	@go build $(BUILD_FLAGS) -o mfx-migrator ./
 	@echo "--> Building project complete"
 
 .PHONY: build

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version is the application version. It can be set during build time using:
+	// go build -ldflags "-X cmd.Version=x.y.z"
+	Version = "dev"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("%s\n", Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
This PR adds a new `version` subcommand printing the binary version.

Fixes #38 