### PR TITLE
fix: remove url validation from root command

### DIFF
--- a/cmd/claim_test.go
+++ b/cmd/claim_test.go
@@ -37,7 +37,7 @@ func TestClaimCmd(t *testing.T) {
 		expected  string
 		endpoints []testutils.HttpResponder
 	}{
-		{name: "no argument", args: []string{}, err: "URL cannot be empty"},
+		{name: "no argument", args: []string{}, err: "url is required"},
 		{name: "username missing", args: urlArg, err: "username is required"},
 		{name: "password missing", args: usernameArg, err: "password is required"},
 		{name: "claim from queue (default neighborhood)", args: passwordArg, endpoints: []testutils.HttpResponder{

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -22,9 +22,9 @@ func TestMigrateCmd(t *testing.T) {
 	testutils.SetupWorkItem(t)
 
 	var slice []string
-	urlArg := append(slice, []string{"--url", testutils.RootUrl}...)
-	uuidArg := append(urlArg, []string{"--uuid", testutils.DummyUUIDStr}...)
-	chainHomeArg := append(uuidArg, []string{"--chain-home", "/tmp"}...)
+	uuidArg := append(slice, []string{"--uuid", testutils.DummyUUIDStr}...)
+	urlArg := append(uuidArg, []string{"--url", testutils.RootUrl}...)
+	chainHomeArg := append(urlArg, []string{"--chain-home", "/tmp"}...)
 	feeGrantArg := append(chainHomeArg, []string{"--fee-granter", "feegranter"}...)
 	usernameArg := append(feeGrantArg, []string{"--username", "user"}...)
 	passwordArg := append(usernameArg, []string{"--password", "pass"}...)
@@ -43,9 +43,9 @@ func TestMigrateCmd(t *testing.T) {
 		err  string
 		out  string
 	}{
-		{name: "no argument", args: []string{}, err: "URL cannot be empty"},
-		{name: "uuid missing", args: urlArg, err: "required flag(s) \"uuid\" not set"},
-		{name: "chain home missing", args: uuidArg, err: "chain home is required"},
+		{name: "no argument", args: []string{}, err: "required flag(s) \"uuid\" not set"},
+		{name: "url missing", args: uuidArg, err: ""},
+		{name: "chain home missing", args: urlArg, err: "chain home is required"},
 		{name: "feegrant missing", args: chainHomeArg, err: "fee granter is required"},
 		{name: "username missing", args: feeGrantArg, err: "username is required"},
 		{name: "password missing", args: usernameArg, err: "password is required"},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"strings"
 
@@ -23,9 +22,6 @@ func RootCmdPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	logLevelArg := viper.GetString("logLevel")
 	urlString := viper.GetString("url")
 	if err := setLogLevel(logLevelArg); err != nil {
-		return err
-	}
-	if err := validateURL(urlString); err != nil {
 		return err
 	}
 
@@ -111,18 +107,5 @@ func setLogLevel(logLevel string) error {
 	}))
 	slog.SetDefault(logger)
 
-	return nil
-}
-
-// validateURL validates a URL is not empty and is a valid URL
-func validateURL(urlStr string) error {
-	if urlStr == "" {
-		return fmt.Errorf("URL cannot be empty")
-	}
-
-	_, err := url.ParseRequestURI(urlStr)
-	if err != nil {
-		return fmt.Errorf("invalid URL: %v", err)
-	}
 	return nil
 }


### PR DESCRIPTION
This PR removes URL validation from the root command. The URLs are verified using the config validation method.