### PR TITLE
feat: migration whitelist and tests

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -99,7 +99,7 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return errors.WithMessage(err, "error getting MANY tx info")
 	}
 
-	var isAllowed = new(bool)
+	var isAllowed = new(string)
 	resp, err := client.R().
 		SetResult(isAllowed).
 		SetPathParam("address", txArgs.From).
@@ -118,7 +118,7 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 	}
 	slog.Info("Result", "result", resp.Result())
 	slog.Info("isAllowed", "isAllowed", isAllowed)
-	if !*isAllowed {
+	if *isAllowed == "false" {
 		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
 	}
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -120,7 +120,6 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 	if err := json.Unmarshal(resp.Body(), &isAllowed); err != nil {
 		return errors.WithMessage(err, "error unmarshalling response")
 	}
-	slog.Info("isAllowed", "isAllowed", isAllowed)
 
 	if !isAllowed {
 		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -116,9 +116,11 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return fmt.Errorf("response status code: %d", statusCode)
 	}
 
+	slog.Info("Result", "result", resp.Result())
+
 	isAllowed := *resp.Result().(*bool)
 	if !isAllowed {
-		return fmt.Errorf("address %s not allowed to migrate", item.ManifestAddress)
+		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
 	}
 
 	return nil

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -100,7 +100,7 @@ func verifyManifestAddressIsAllowed(item *store.WorkItem, client *resty.Client) 
 	}
 
 	resp, err := client.R().
-		SetResult([]string{}).
+		SetResult(&[]string{}).
 		Get("migrations-whitelist")
 	if err != nil {
 		return errors.WithMessage(err, "error getting migration whitelisted addresses")

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -110,11 +110,13 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return fmt.Errorf("no response returned when getting migration whitelisted addresses")
 	}
 
+	slog.Info("Response", "response", resp)
+	slog.Info("Response Body", "response", resp.Body())
+
 	statusCode := resp.StatusCode()
 	if statusCode != 200 {
 		return fmt.Errorf("response status code: %d", statusCode)
 	}
-	slog.Info("Result", "result", resp.Result())
 	//slog.Info("isAllowed", "isAllowed", isAllowed)
 	//if *isAllowed == "false" {
 	//	return fmt.Errorf("address %s not allowed to migrate", txArgs.From)

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -100,7 +100,6 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 	}
 
 	resp, err := client.R().
-		SetResult(bool(false)).
 		SetPathParam("address", txArgs.From).
 		Get("migrations-whitelist/{address}")
 	if err != nil {
@@ -115,10 +114,10 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 	if statusCode != 200 {
 		return fmt.Errorf("response status code: %d", statusCode)
 	}
-
 	slog.Info("Result", "result", resp.Result())
 
-	isAllowed := *resp.Result().(*bool)
+	isAllowed := resp.Result().(bool)
+	slog.Info("isAllowed", "isAllowed", isAllowed)
 	if !isAllowed {
 		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
 	}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -99,9 +99,7 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return errors.WithMessage(err, "error getting MANY tx info")
 	}
 
-	var isAllowed = new(string)
 	resp, err := client.R().
-		SetResult(isAllowed).
 		SetPathParam("address", txArgs.From).
 		Get("migrations-whitelist/{address}")
 	if err != nil {
@@ -117,10 +115,10 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return fmt.Errorf("response status code: %d", statusCode)
 	}
 	slog.Info("Result", "result", resp.Result())
-	slog.Info("isAllowed", "isAllowed", isAllowed)
-	if *isAllowed == "false" {
-		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
-	}
+	//slog.Info("isAllowed", "isAllowed", isAllowed)
+	//if *isAllowed == "false" {
+	//	return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
+	//}
 
 	return nil
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -99,7 +99,9 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return errors.WithMessage(err, "error getting MANY tx info")
 	}
 
+	var isAllowed = new(bool)
 	resp, err := client.R().
+		SetResult(isAllowed).
 		SetPathParam("address", txArgs.From).
 		Get("migrations-whitelist/{address}")
 	if err != nil {
@@ -115,10 +117,8 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return fmt.Errorf("response status code: %d", statusCode)
 	}
 	slog.Info("Result", "result", resp.Result())
-
-	isAllowed := resp.Result().(bool)
 	slog.Info("isAllowed", "isAllowed", isAllowed)
-	if !isAllowed {
+	if !*isAllowed {
 		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
 	}
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -110,17 +111,20 @@ func verifyManyAddressIsAllowed(item *store.WorkItem, client *resty.Client) erro
 		return fmt.Errorf("no response returned when getting migration whitelisted addresses")
 	}
 
-	slog.Info("Response", "response", resp)
-	slog.Info("Response Body", "response", resp.Body())
-
 	statusCode := resp.StatusCode()
 	if statusCode != 200 {
 		return fmt.Errorf("response status code: %d", statusCode)
 	}
-	//slog.Info("isAllowed", "isAllowed", isAllowed)
-	//if *isAllowed == "false" {
-	//	return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
-	//}
+
+	var isAllowed bool
+	if err := json.Unmarshal(resp.Body(), &isAllowed); err != nil {
+		return errors.WithMessage(err, "error unmarshalling response")
+	}
+	slog.Info("isAllowed", "isAllowed", isAllowed)
+
+	if !isAllowed {
+		return fmt.Errorf("address %s not allowed to migrate", txArgs.From)
+	}
 
 	return nil
 }

--- a/interchaintest/migrate_on_chain_test.go
+++ b/interchaintest/migrate_on_chain_test.go
@@ -88,7 +88,7 @@ func TestMigrateOnChain(t *testing.T) {
 	}{
 		{name: "1:1000 tokens", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
-			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
+			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("1000")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -98,7 +98,7 @@ func TestMigrateOnChain(t *testing.T) {
 		}},
 		{name: "insufficient funds", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
-			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
+			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder(defaultGenesisAmtPlusThousand.String())},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -108,7 +108,7 @@ func TestMigrateOnChain(t *testing.T) {
 		}, err: "insufficient funds"},
 		{name: "invalid coins", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
-			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
+			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("0")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -118,7 +118,7 @@ func TestMigrateOnChain(t *testing.T) {
 		}, err: "invalid coins"},
 		{name: "all tokens from bank", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
-			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
+			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewMultisigTransactionResponseResponder(defaultGenesisAmtMinThousand.String())},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -128,14 +128,14 @@ func TestMigrateOnChain(t *testing.T) {
 		}},
 		{name: "non-whitelisted address", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
-			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.InvalidWhiteListResponder},
+			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.InvalidWhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("1000")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
 		}, expected: Expected{
 			Bank: Amounts{Old: math.ZeroInt()},
 			User: Amounts{Old: DefaultGenesisAmt},
-		}, err: "not in whitelist",
+		}, err: "not allowed to migrate",
 		},
 	}
 

--- a/interchaintest/migrate_on_chain_test.go
+++ b/interchaintest/migrate_on_chain_test.go
@@ -88,6 +88,7 @@ func TestMigrateOnChain(t *testing.T) {
 	}{
 		{name: "1:1000 tokens", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
+			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("1000")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -97,6 +98,7 @@ func TestMigrateOnChain(t *testing.T) {
 		}},
 		{name: "insufficient funds", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
+			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder(defaultGenesisAmtPlusThousand.String())},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -106,6 +108,7 @@ func TestMigrateOnChain(t *testing.T) {
 		}, err: "insufficient funds"},
 		{name: "invalid coins", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
+			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("0")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -115,6 +118,7 @@ func TestMigrateOnChain(t *testing.T) {
 		}, err: "invalid coins"},
 		{name: "all tokens from bank", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
+			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
 			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewMultisigTransactionResponseResponder(defaultGenesisAmtMinThousand.String())},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
@@ -122,6 +126,17 @@ func TestMigrateOnChain(t *testing.T) {
 			Bank: Amounts{Old: defaultGenesisAmtMinThousand, New: math.ZeroInt()},
 			User: Amounts{Old: math.NewInt(1000), New: DefaultGenesisAmt},
 		}},
+		{name: "non-whitelisted address", args: slice, endpoints: []testutils.HttpResponder{
+			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
+			{Method: "GET", Url: testutils.WhiteListUrl, Responder: testutils.InvalidWhiteListResponder},
+			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
+			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("1000")},
+			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
+		}, expected: Expected{
+			Bank: Amounts{Old: math.ZeroInt()},
+			User: Amounts{Old: DefaultGenesisAmt},
+		}, err: "not in whitelist",
+		},
 	}
 
 	for _, tc := range tt {

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -20,5 +20,5 @@ var (
 	ClaimUrl     = RootUrl + fmt.Sprintf("neighborhoods/%s/migrations/claim/", Neighborhood)
 	ClaimUuidUrl = ClaimUrl + Uuidv4Regex
 	LoginUrl     = RootUrl + "auth/login"
-	WhiteListUrl = RootUrl + "migrations-whitelist"
+	WhiteListUrl = RootUrl + "migrations-whitelist/" + "[a-zA-Z0-9]{1,}"
 )

--- a/testutils/http.go
+++ b/testutils/http.go
@@ -20,4 +20,5 @@ var (
 	ClaimUrl     = RootUrl + fmt.Sprintf("neighborhoods/%s/migrations/claim/", Neighborhood)
 	ClaimUuidUrl = ClaimUrl + Uuidv4Regex
 	LoginUrl     = RootUrl + "auth/login"
+	WhiteListUrl = RootUrl + "migrations-whitelist"
 )

--- a/testutils/httpresponder.go
+++ b/testutils/httpresponder.go
@@ -32,8 +32,8 @@ type HttpResponder struct {
 }
 
 var AuthResponder, _ = httpmock.NewJsonResponder(http.StatusOK, map[string]string{"access_token": "ya29.Gl0UBZ3"})
-var WhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{ManifestAddress})
-var InvalidWhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{"manifest1hj5fveer5cjtn4wd6wstzugjfdxzl0xp8ws9ct"})
+var WhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{ManyFrom})
+var InvalidWhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{"invalid"})
 
 func MustNewLedgerSendTransactionResponseResponder(amount string) httpmock.Responder {
 	args := many.Arguments{

--- a/testutils/httpresponder.go
+++ b/testutils/httpresponder.go
@@ -32,6 +32,8 @@ type HttpResponder struct {
 }
 
 var AuthResponder, _ = httpmock.NewJsonResponder(http.StatusOK, map[string]string{"access_token": "ya29.Gl0UBZ3"})
+var WhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{ManifestAddress})
+var InvalidWhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{"manifest1hj5fveer5cjtn4wd6wstzugjfdxzl0xp8ws9ct"})
 
 func MustNewLedgerSendTransactionResponseResponder(amount string) httpmock.Responder {
 	args := many.Arguments{

--- a/testutils/httpresponder.go
+++ b/testutils/httpresponder.go
@@ -32,8 +32,8 @@ type HttpResponder struct {
 }
 
 var AuthResponder, _ = httpmock.NewJsonResponder(http.StatusOK, map[string]string{"access_token": "ya29.Gl0UBZ3"})
-var WhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{ManyFrom})
-var InvalidWhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, []string{"invalid"})
+var WhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, true)
+var InvalidWhiteListResponder, _ = httpmock.NewJsonResponder(http.StatusOK, false)
 
 func MustNewLedgerSendTransactionResponseResponder(amount string) httpmock.Responder {
 	args := many.Arguments{


### PR DESCRIPTION
This pull request introduces a new feature for verifying that a migration manifest address is in a whitelist before proceeding with token migration. Additionally, it includes updates to the corresponding tests and utility functions to support this new feature.

### New Feature Implementation:

* [`cmd/migrate.go`](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dL59-R76): Added the `verifyManifestAddressIsAllowed` function to check if the manifest address is in the whitelist before allowing the migration to proceed. If the address is not in the whitelist, the migration is marked as failed. [[1]](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dL59-R76) [[2]](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dR96-R129)

### Test Updates:

* [`interchaintest/migrate_on_chain_test.go`](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcR91): Updated the `TestMigrateOnChain` test to include scenarios for whitelisted and non-whitelisted addresses. Added the `WhiteListResponder` and `InvalidWhiteListResponder` to simulate whitelist checks. [[1]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcR91) [[2]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcR101) [[3]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcR111) [[4]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcR121-R139)

### Utility Functions:

* [`testutils/http.go`](diffhunk://#diff-75d56f6ef76ac4c4c5d1056308fe87c38740ebbe5e45587b960457334699e308R23): Added `WhiteListUrl` to define the endpoint for fetching the whitelist.
* [`testutils/httpresponder.go`](diffhunk://#diff-92d62ed137fb982b5b3d62268bf8b7c084efab26528d04f26a1842dc8e8e2583R35-R36): Added `WhiteListResponder` and `InvalidWhiteListResponder` to simulate responses for whitelist checks in tests.

### Import Changes:

* [`cmd/migrate.go`](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dR8): Added the `slices` package to the import list to utilize its functions.

Relates https://github.com/liftedinit/talib/pull/371
Relates https://github.com/fmorency/alberto/pull/1