### PR TITLE
fix: new split

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -286,7 +286,6 @@ func migrate(r *resty.Client, item *store.WorkItem, config config.MigrateConfig)
 	// The MANY chain supports 9 decimal places
 	// The MANIFEST chain supports 6 decimal places
 	// Perform a 1:100 split
-	// If amount is 100000000, we want to send 100000000 * 100 = 10000000000
 	// 1 MFX on the MANY chain = 100 MFX on the MANIFEST chain
 	newAmount := new(big.Int)
 	newAmount.Quo(amount, big.NewInt(10))

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -65,6 +65,7 @@ func MigrateCmdRunE(cmd *cobra.Command, args []string) error {
 	if err := verifyManyAddressIsAllowed(item, r); err != nil {
 		// An unauthorized address scheduled a migration
 		// Mark the migration as failed
+		slog.Error("Migration failed", "error", err)
 		errStr := err.Error()
 		sErr := setAsFailed(r, *item, &errStr)
 		if sErr != nil {
@@ -78,6 +79,7 @@ func MigrateCmdRunE(cmd *cobra.Command, args []string) error {
 
 	// The migration failed for some reason, update the work item status and save the state
 	if err != nil {
+		slog.Error("Migration failed", "error", err)
 		errStr := err.Error()
 		sErr := setAsFailed(r, *item, &errStr)
 		if sErr != nil {
@@ -264,7 +266,7 @@ func migrate(r *resty.Client, item *store.WorkItem, config config.MigrateConfig)
 		return errors.WithMessage(err, "error mapping token")
 	}
 
-	slog.Debug("Amount", "amount", txArgs.Amount)
+	slog.Debug("Original amount", "amount", txArgs.Amount)
 
 	var newItem = *item
 
@@ -281,8 +283,18 @@ func migrate(r *resty.Client, item *store.WorkItem, config config.MigrateConfig)
 		return fmt.Errorf("error parsing big.Int: %s", txArgs.Amount)
 	}
 
+	// The MANY chain supports 9 decimal places
+	// The MANIFEST chain supports 6 decimal places
+	// Perform a 1:100 split
+	// If amount is 100000000, we want to send 100000000 * 100 = 10000000000
+	// 1 MFX on the MANY chain = 100 MFX on the MANIFEST chain
+	newAmount := new(big.Int)
+	newAmount.Quo(amount, big.NewInt(10))
+
+	slog.Info("NEW AMOUNT", "newAmount", newAmount.String())
+
 	// Send the tokens
-	txHash, blockTime, err := sendTokens(&newItem, config, tokenInfo.Denom, amount)
+	txHash, blockTime, err := sendTokens(&newItem, config, tokenInfo.Denom, newAmount)
 	if err != nil {
 		return errors.WithMessage(err, "error sending tokens")
 	}

--- a/interchaintest/const.go
+++ b/interchaintest/const.go
@@ -83,5 +83,5 @@ var (
 		ModifyGenesis:  cosmos.ModifyGenesis(DefaultGenesis),
 	}
 
-	DefaultGenesisAmt = sdkmath.NewInt(10_000_000)
+	DefaultGenesisAmt = sdkmath.NewInt(10_000_000_000)
 )


### PR DESCRIPTION
This pull request includes several changes to the migration process, focusing on improving logging, adjusting token amounts, and updating tests to reflect these changes. The most important changes include adding error logging, modifying token amounts for the MANY and MANIFEST chains, and updating test cases accordingly.

### Logging Improvements:
* Added error logging in `MigrateCmdRunE` to capture migration failures. (`cmd/migrate.go`) [[1]](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dR68) [[2]](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dR82)

### Token Amount Adjustments:
* Changed debug log message to specify "Original amount" in `migrate` function. (`cmd/migrate.go`)
* Implemented a 1:100 token split between MANY and MANIFEST chains and updated the amount calculation accordingly. (`cmd/migrate.go`)
* Updated `DefaultGenesisAmt` to reflect the new token amount. (`interchaintest/const.go`)

### Test Updates:
* Adjusted test cases in `TestMigrateOnChain` to reflect the new token conversion and amount checks. (`interchaintest/migrate_on_chain_test.go`) [[1]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL79-R81) [[2]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL89-R145)

### Additional Changes:
* Added `math/big` import and implemented amount validation in `CheckTxInfo` to ensure amounts are not dust in the conversion process. (`internal/many/tx.go`) [[1]](diffhunk://#diff-3b262b12fd6711c5f71b29ae5b3602ac414eb8b3757b741366951655afe044a7R6) [[2]](diffhunk://#diff-3b262b12fd6711c5f71b29ae5b3602ac414eb8b3757b741366951655afe044a7R91-R104)