### PR TITLE
fix: 1:10 split

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -285,10 +285,10 @@ func migrate(r *resty.Client, item *store.WorkItem, config config.MigrateConfig)
 
 	// The MANY chain supports 9 decimal places
 	// The MANIFEST chain supports 6 decimal places
-	// Perform a 1:100 split
-	// 1 MFX on the MANY chain = 100 MFX on the MANIFEST chain
+	// Perform a 1:10 split
+	// 1 MFX on the MANY chain = 10 MFX on the MANIFEST chain
 	newAmount := new(big.Int)
-	newAmount.Quo(amount, big.NewInt(10))
+	newAmount.Quo(amount, big.NewInt(100))
 
 	slog.Info("NEW AMOUNT", "newAmount", newAmount.String())
 

--- a/interchaintest/migrate_on_chain_test.go
+++ b/interchaintest/migrate_on_chain_test.go
@@ -77,7 +77,7 @@ func TestMigrateOnChain(t *testing.T) {
 	}
 
 	amtToTruncate := math.NewInt(1123456789)
-	amtTruncated := math.NewInt(112345678)
+	amtTruncated := math.NewInt(11234567)
 	defaultGenesisAmtMinOne := DefaultGenesisAmt.Sub(math.OneInt()) // Genesis amount - 1
 
 	tt := []struct {
@@ -91,7 +91,7 @@ func TestMigrateOnChain(t *testing.T) {
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
 			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
-			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("10")},
+			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("100")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
 		}, expected: Expected{
 			Bank: Amounts{Old: DefaultGenesisAmt, New: defaultGenesisAmtMinOne},
@@ -107,17 +107,16 @@ func TestMigrateOnChain(t *testing.T) {
 			Bank: Amounts{Old: defaultGenesisAmtMinOne, New: defaultGenesisAmtMinOne.Sub(amtTruncated)},
 			User: Amounts{Old: math.OneInt(), New: amtTruncated.Add(math.OneInt())},
 		}},
-		{name: "minimum amount is 10", args: slice, endpoints: []testutils.HttpResponder{
+		{name: "minimum amount is 100", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
 			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
-			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("9")},
+			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewLedgerSendTransactionResponseResponder("99")},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
 		}, expected: Expected{
 			Bank: Amounts{Old: defaultGenesisAmtMinOne.Sub(amtTruncated)},
 			User: Amounts{Old: amtTruncated.Add(math.OneInt())},
 		}, err: "amount must be greater"},
-
 		{name: "insufficient funds", args: slice, endpoints: []testutils.HttpResponder{
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
 			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
@@ -132,7 +131,7 @@ func TestMigrateOnChain(t *testing.T) {
 			{Method: "POST", Url: testutils.LoginUrl, Responder: testutils.AuthResponder},
 			{Method: "GET", Url: "=~^" + testutils.WhiteListUrl, Responder: testutils.WhiteListResponder},
 			{Method: "GET", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MustMigrationGetResponder(store.CLAIMED)},
-			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewMultisigTransactionResponseResponder(defaultGenesisAmtMinOne.Sub(amtTruncated).Mul(math.NewInt(10)).String())},
+			{Method: "GET", Url: "=~^" + testutils.DefaultTransactionUrl, Responder: testutils.MustNewMultisigTransactionResponseResponder(defaultGenesisAmtMinOne.Sub(amtTruncated).Mul(math.NewInt(100)).String())},
 			{Method: "PUT", Url: "=~^" + testutils.DefaultMigrationUrl, Responder: testutils.MigrationUpdateResponder},
 		}, expected: Expected{
 			Bank: Amounts{Old: defaultGenesisAmtMinOne.Sub(amtTruncated), New: math.ZeroInt()},

--- a/internal/many/tx.go
+++ b/internal/many/tx.go
@@ -96,10 +96,10 @@ func CheckTxInfo(txArgs *Arguments, itemUUID uuid.UUID, manifestAddr string) err
 
 	// The MANY chain supports 9 decimal places
 	// The MANIFEST chain support 6 decimal places
-	// We're doing a 1:100 conversion
+	// We're doing a 1:10 conversion
 	// Check the amount is not dust that would be lost in the conversion
-	if bigAmount.Cmp(big.NewInt(10)) < 0 {
-		return fmt.Errorf("amount must be greater than 0.000000009: %s", txArgs.Amount)
+	if bigAmount.Cmp(big.NewInt(100)) < 0 {
+		return fmt.Errorf("amount must be greater than 0.000000099: %s", txArgs.Amount)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request updates the conversion ratio and related logic for migrating assets between the MANY and MANIFEST chains, changing the split from 1:100 to 1:10. Corresponding updates have been made to the migration logic, test cases, and validation rules to align with this new conversion ratio.

### Migration Logic Updates:
* Updated the conversion ratio in `func migrate` within `cmd/migrate.go` to reflect a 1:10 split, adjusting the calculation of `newAmount` accordingly. (`[cmd/migrate.goL288-R291](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dL288-R291)`)
* Modified the validation logic in `internal/many/tx.go` to ensure amounts are greater than 0.000000099 instead of 0.000000009, reflecting the updated split ratio. (`[internal/many/tx.goL99-R102](diffhunk://#diff-3b262b12fd6711c5f71b29ae5b3602ac414eb8b3757b741366951655afe044a7L99-R102)`)

### Test Case Adjustments:
* Updated expected truncated amounts and minimum thresholds in `TestMigrateOnChain` within `interchaintest/migrate_on_chain_test.go` to align with the new 1:10 split:
  - Adjusted `amtTruncated` and related calculations. (`[interchaintest/migrate_on_chain_test.goL80-R80](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL80-R80)`)
  - Updated mock responses for transaction values to reflect the new split ratio. (`[[1]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL94-R94)`, `[[2]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL135-R134)`)
  - Renamed test case descriptions to reflect the updated minimum amount (e.g., "minimum amount is 100"). (`[interchaintest/migrate_on_chain_test.goL110-L120](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL110-L120)`)