### PR TITLE
chore: increase request timeout

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -34,10 +34,10 @@ func CreateRestClient(ctx context.Context, url string, neighborhood uint64) *res
 	return client.
 		SetBaseURL(url).
 		SetPathParam("neighborhood", strconv.FormatUint(neighborhood, 10)).
-		SetRetryCount(3).                      // Retry the request process 3 times. Retry uses an exponential backoff algorithm.
-		SetRetryWaitTime(5 * time.Second).     // With a 5 seconds wait time between retries
-		SetRetryMaxWaitTime(60 * time.Second). // And a maximum wait time of 60 seconds for the whole process
-		SetTimeout(10 * time.Second)           // Set a timeout of 10 seconds for the request
+		SetRetryCount(10). // Retry the request process 3 times. Retry uses an exponential backoff algorithm.
+		SetRetryWaitTime(5 * time.Second). // With a 5 seconds wait time between retries
+		SetRetryMaxWaitTime(10 * time.Minute). // And a maximum wait time of 60 seconds for the whole process
+		SetTimeout(20 * time.Second) // Set a timeout of 10 seconds for the request
 }
 
 // AuthenticateRestClient logs in to the remote database


### PR DESCRIPTION
This pull request updates the retry and timeout settings for the `CreateRestClient` function in `cmd/common.go`. The changes aim to improve the robustness of the client by increasing the retry count, retry wait time, and timeout duration.

Updates to retry and timeout settings:

* [`cmd/common.go`](diffhunk://#diff-2b0546a527b3560f4e7f8501ef7907999b2e1a7f2498a60719630310f7778956L37-R40): Increased the retry count from 3 to 10 to improve request resilience.
* [`cmd/common.go`](diffhunk://#diff-2b0546a527b3560f4e7f8501ef7907999b2e1a7f2498a60719630310f7778956L37-R40): Updated the maximum retry wait time from 60 seconds to 10 minutes to allow longer recovery periods for retries.
* [`cmd/common.go`](diffhunk://#diff-2b0546a527b3560f4e7f8501ef7907999b2e1a7f2498a60719630310f7778956L37-R40): Increased the timeout for requests from 10 seconds to 20 seconds to accommodate slower responses.