### PR TITLE
chore: move gh org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ jobs:
             key: *go_mod_cache_key
       - run:
           name: Pull manifest-ledger Docker image
-          command: docker pull ghcr.io/liftedinit/manifest-ledger:v1.0.3
+          command: docker pull ghcr.io/manifest-network/manifest-ledger:1.0.8
       - run:
           name: Install manifestd from manifest-ledger Docker image
           command: |
-            id=$(docker create ghcr.io/liftedinit/manifest-ledger:v1.0.3)
+            id=$(docker create ghcr.io/manifest-network/manifest-ledger:1.0.8)
             docker cp $id:/usr/bin/manifestd /tmp/manifestd
             sudo mv /tmp/manifestd /usr/local/bin/
             docker rm -v $id

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/liftedinit/mfx-migrator/cmd.Version={{.Version}}
+      - -X github.com/manifest-network/mfx-migrator/cmd.Version={{.Version}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## Display this help screen
 #### BUILD ####
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-BUILD_FLAGS := -ldflags "-X github.com/liftedinit/mfx-migrator/cmd.Version=$(VERSION)"
+BUILD_FLAGS := -ldflags "-X github.com/manifest-network/mfx-migrator/cmd.Version=$(VERSION)"
 
 build: ## Build the project
 	@echo "--> Building project (version: $(VERSION))"
@@ -67,7 +67,7 @@ format-install:
 format: ## Run formatter (goimports)
 	@echo "--> Running goimports"
 	$(MAKE) format-install
-	@find . -name '*.go' -exec goimports -w -local github.com/liftedinit/mfx-migrator {} \;
+	@find . -name '*.go' -exec goimports -w -local github.com/manifest-network/mfx-migrator {} \;
 
 #### GOVULNCHECK ####
 govulncheck_version=latest
@@ -94,7 +94,7 @@ vet: ## Run go vet
 
 coverage: ## Run coverage report
 	@echo "--> Running coverage"
-	@go test -race -cpu=$$(nproc) -covermode=atomic -coverprofile=coverage.out $$(go list ./...) ./interchaintest/... -coverpkg=github.com/liftedinit/mfx-migrator/... > /dev/null 2>&1
+	@go test -race -cpu=$$(nproc) -covermode=atomic -coverprofile=coverage.out $$(go list ./...) ./interchaintest/... -coverpkg=github.com/manifest-network/mfx-migrator/... > /dev/null 2>&1
 	@echo "--> Running coverage filter"
 	@./scripts/filter-coverage.sh
 	@echo "--> Running coverage report"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![build](https://img.shields.io/circleci/build/github/liftedinit/mfx-migrator/main)](https://app.circleci.com/pipelines/github/liftedinit/mfx-migrator)
-[![coverage](https://img.shields.io/codecov/c/github/liftedinit/mfx-migrator)](https://app.codecov.io/gh/liftedinit/mfx-migrator)
-[![Go Report Card](https://goreportcard.com/badge/github.com/liftedinit/mfx-migrator)](https://goreportcard.com/report/github.com/liftedinit/mfx-migrator)
+[![build](https://img.shields.io/circleci/build/github/manifest-network/mfx-migrator/main)](https://app.circleci.com/pipelines/github/manifest-network/mfx-migrator)
+[![coverage](https://img.shields.io/codecov/c/github/manifest-network/mfx-migrator)](https://app.codecov.io/gh/manifest-network/mfx-migrator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/manifest-network/mfx-migrator)](https://goreportcard.com/report/github.com/manifest-network/mfx-migrator)
 
 
 **mfx-migrator** is a centralized daemon responsible for migrating data from the old MANY chain to the new MANIFEST chain. 

--- a/cmd/claim.go
+++ b/cmd/claim.go
@@ -9,9 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/mfx-migrator/internal/config"
+	"github.com/manifest-network/mfx-migrator/internal/config"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 // claimCmd represents the claim command

--- a/cmd/claim_test.go
+++ b/cmd/claim_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 
-	"github.com/liftedinit/mfx-migrator/cmd"
-	"github.com/liftedinit/mfx-migrator/testutils"
+	"github.com/manifest-network/mfx-migrator/cmd"
+	"github.com/manifest-network/mfx-migrator/testutils"
 )
 
 func TestClaimCmd(t *testing.T) {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/mfx-migrator/internal/config"
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/config"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 const RestyClientKey store.ContextKey = "restyClient"
@@ -34,10 +34,10 @@ func CreateRestClient(ctx context.Context, url string, neighborhood uint64) *res
 	return client.
 		SetBaseURL(url).
 		SetPathParam("neighborhood", strconv.FormatUint(neighborhood, 10)).
-		SetRetryCount(10). // Retry the request process 3 times. Retry uses an exponential backoff algorithm.
-		SetRetryWaitTime(5 * time.Second). // With a 5 seconds wait time between retries
+		SetRetryCount(10).                     // Retry the request process 3 times. Retry uses an exponential backoff algorithm.
+		SetRetryWaitTime(5 * time.Second).     // With a 5 seconds wait time between retries
 		SetRetryMaxWaitTime(10 * time.Minute). // And a maximum wait time of 60 seconds for the whole process
-		SetTimeout(20 * time.Second) // Set a timeout of 10 seconds for the request
+		SetTimeout(20 * time.Second)           // Set a timeout of 10 seconds for the request
 }
 
 // AuthenticateRestClient logs in to the remote database

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -13,13 +13,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/mfx-migrator/internal/config"
+	"github.com/manifest-network/mfx-migrator/internal/config"
 
-	"github.com/liftedinit/mfx-migrator/internal/many"
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/many"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 
-	"github.com/liftedinit/mfx-migrator/internal/manifest"
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/manifest"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 // migrateCmd represents the migrate command

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/cmd"
-	"github.com/liftedinit/mfx-migrator/testutils"
+	"github.com/manifest-network/mfx-migrator/cmd"
+	"github.com/manifest-network/mfx-migrator/testutils"
 )
 
 func TestMigrateCmd(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 // verifyCmd represents the verify command

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/liftedinit/mfx-migrator
+module github.com/manifest-network/mfx-migrator
 
 go 1.23.10
 

--- a/interchaintest/const.go
+++ b/interchaintest/const.go
@@ -23,8 +23,8 @@ const (
 	chainType       = "cosmos"
 	chainName       = "manifest-ledger"
 	chainID         = "manifest-2"
-	chainRepository = "ghcr.io/liftedinit/manifest-ledger"
-	chainVersion    = "v1.0.3"
+	chainRepository = "ghcr.io/manifest-network/manifest-ledger"
+	chainVersion    = "1.0.8"
 )
 
 var (

--- a/interchaintest/go.mod
+++ b/interchaintest/go.mod
@@ -1,4 +1,4 @@
-module github.com/liftedinit/mfx-migrator/interchaintest
+module github.com/manifest-network/mfx-migrator/interchaintest
 
 go 1.23.10
 
@@ -8,15 +8,15 @@ replace (
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 	github.com/ChainSafe/go-schnorrkel/1 => github.com/ChainSafe/go-schnorrkel v1.0.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/liftedinit/mfx-migrator => ../
+	github.com/manifest-network/mfx-migrator => ../
 )
 
 require (
 	cosmossdk.io/math v1.4.0
-	github.com/cosmos/cosmos-sdk v0.50.12
+	github.com/cosmos/cosmos-sdk v0.50.14
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/jarcoal/httpmock v1.3.1
-	github.com/liftedinit/mfx-migrator v0.0.0-00000000000000-000000000000
+	github.com/manifest-network/mfx-migrator v0.0.0-00000000000000-000000000000
 	github.com/spf13/cobra v1.8.1
 	github.com/strangelove-ventures/interchaintest/v8 v8.2.0
 	github.com/strangelove-ventures/poa v0.50.6

--- a/interchaintest/go.sum
+++ b/interchaintest/go.sum
@@ -366,8 +366,8 @@ github.com/cosmos/cosmos-db v1.1.1 h1:FezFSU37AlBC8S98NlSagL76oqBRWq/prTPvFcEJNC
 github.com/cosmos/cosmos-db v1.1.1/go.mod h1:AghjcIPqdhSLP/2Z0yha5xPH3nLnskz81pBx3tcVSAw=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.50.12 h1:WizeD4K74737Gq46/f9fq+WjyZ1cP/1bXwVR3dvyp0g=
-github.com/cosmos/cosmos-sdk v0.50.12/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
+github.com/cosmos/cosmos-sdk v0.50.14 h1:G8CtGHFWbExa+ZpVOVAb4kFmko/R30igsYOwyzRMtgY=
+github.com/cosmos/cosmos-sdk v0.50.14/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=

--- a/interchaintest/migrate_on_chain_test.go
+++ b/interchaintest/migrate_on_chain_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 
-	"github.com/liftedinit/mfx-migrator/cmd"
-	"github.com/liftedinit/mfx-migrator/testutils"
+	"github.com/manifest-network/mfx-migrator/cmd"
+	"github.com/manifest-network/mfx-migrator/testutils"
 )
 
 type Amounts struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 )
 
 // Config represents the configuration for the command

--- a/internal/manifest/migrate.go
+++ b/internal/manifest/migrate.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/liftedinit/mfx-migrator/internal/config"
+	"github.com/manifest-network/mfx-migrator/internal/config"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 const (

--- a/internal/store/claim_test.go
+++ b/internal/store/claim_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/testutils"
+	"github.com/manifest-network/mfx-migrator/testutils"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 type testCase struct {

--- a/internal/store/state_test.go
+++ b/internal/store/state_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 func TestSaveLoadState(t *testing.T) {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 )
 
 type Token struct {

--- a/internal/store/types_test.go
+++ b/internal/store/types_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 func TestTypes_WorkItemStatus(t *testing.T) {

--- a/internal/store/update.go
+++ b/internal/store/update.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/pkg/errors"
 
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 )
 
 // UpdateWorkItemAndSaveState updates a work item in the remote database and saves the state locally.

--- a/internal/utils/ptr_test.go
+++ b/internal/utils/ptr_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 )
 
 func TestPtr(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/liftedinit/mfx-migrator/cmd"
+import "github.com/manifest-network/mfx-migrator/cmd"
 
 func main() {
 	cmd.Execute()

--- a/testutils/httpresponder.go
+++ b/testutils/httpresponder.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jarcoal/httpmock"
 
-	"github.com/liftedinit/mfx-migrator/internal/many"
-	"github.com/liftedinit/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/many"
+	"github.com/manifest-network/mfx-migrator/internal/store"
 )
 
 // TODO: Randomize parameters. Fuzzy testing.

--- a/testutils/workitem.go
+++ b/testutils/workitem.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
 
-	"github.com/liftedinit/mfx-migrator/internal/store"
-	"github.com/liftedinit/mfx-migrator/internal/utils"
+	"github.com/manifest-network/mfx-migrator/internal/store"
+	"github.com/manifest-network/mfx-migrator/internal/utils"
 )
 
 const (


### PR DESCRIPTION
This pull request updates the project to use the new `manifest-network` organization and repository naming, replacing all references to the old `liftedinit` organization. This includes updates to import paths, module names, Docker image sources, and documentation links. Additionally, dependencies and configuration files have been updated to reflect these changes.

**Repository and import path migration:**

* Changed all Go module names and import paths from `github.com/liftedinit/mfx-migrator` to `github.com/manifest-network/mfx-migrator` throughout the codebase, including in `go.mod`, `interchaintest/go.mod`, and all Go source files. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1) [[2]](diffhunk://#diff-47bb94237d26bfffe92c2ed51ecc5f4e680609daa6553f1c37b4aecaf348d55eL1-R1) [[3]](diffhunk://#diff-9449f36886a06a5250e3c57ebca9e65f16c9397bfa2710ee5007608e1c2cd7a2L12-R14) [[4]](diffhunk://#diff-e628f086745420fea597fa95417e8a85c92445ff412e874221849dff270a5e9dL13-R16) [[5]](diffhunk://#diff-2b0546a527b3560f4e7f8501ef7907999b2e1a7f2498a60719630310f7778956L14-R17) [[6]](diffhunk://#diff-b32fe0c09b5f6e643dead8a82d0f9aea68b0d74249f38c6d7fe1e2a633dc879dL16-R22) [[7]](diffhunk://#diff-3375fd6a0346ceac19fa74e653e4f68236a10d3e37c9c567a42b54538ef18cfaL13-R14) [[8]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL12-R12) [[9]](diffhunk://#diff-e300947dcbe4504ad7c19feb31d7d605a77cdaa69f2e193cbb1f3143c3fc8471L11-R11) [[10]](diffhunk://#diff-bee459d3742e0b533a47dbba5dad4fdad56c39f4cf31c09fb9b9dc91417574fcL16-R19) [[11]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL10-R10) [[12]](diffhunk://#diff-0aff57e6d3f01e7b30d1003011dae051cc3b77b2f4f2c453475c71d8a58f98a8L13-R15) [[13]](diffhunk://#diff-7a0c1ce72541b1fe2c0ae7701315ed392ef8ce6e6307fda10e0adb2d03a14e94L13-R15) [[14]](diffhunk://#diff-549c3b2da53a5e96a5b36c3f49a1ca433078b67c5c0d05f9660a05112c9ae1d6L10-R10) [[15]](diffhunk://#diff-bf4da8dbcca52b9f77d8cdd2f98fe94f3b409d24637afa9ad2b6131cb0eb2d28L8-R8)

**Build and CI configuration updates:**

* Updated Docker image references and versions in `.circleci/config.yml` and `interchaintest/const.go` to use the new `manifest-network/manifest-ledger` image and version `1.0.8`. [[1]](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L29-R33) [[2]](diffhunk://#diff-09596f2486cf46ee4b7aac193bc89b9096f17f2f77f64d72f41eafe87cd0f199L26-R27)
* Changed all build flags, formatter settings, and coverage settings in `Makefile` and `.goreleaser.yaml` to use the new module path. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L10-R10) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L70-R70) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L97-R97) [[4]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L37-R37)

**Documentation and badge updates:**

* Updated all documentation badges and links in `README.md` to point to the new GitHub organization and repository.

**Dependency and test configuration:**

* Updated dependencies and replace directives in `interchaintest/go.mod` to use the new module path and the latest version of `cosmos-sdk`.

These changes ensure the project is fully migrated to the new organization and repository structure.