### PR TITLE
fix: update base image from buster-slim to bookworm-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o mfx-migrator .
 
 # Start from a Debian Slim image to keep the final image size down.
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 # Install cron to schedule the job.
 RUN apt-get update && apt-get install -y cron jq && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request makes a small update to the base image used in the `Dockerfile` for building and deploying the application.

* Updated the base image from `debian:buster-slim` to `debian:bookworm-slim` to ensure the application uses a more recent and secure version of Debian.